### PR TITLE
feat(prod): kbk volumes on encrypted storage class

### DIFF
--- a/k8s/overlays/prod/kbk-pvc-storage-patch.yaml
+++ b/k8s/overlays/prod/kbk-pvc-storage-patch.yaml
@@ -1,0 +1,25 @@
+# Prod-only: kbk volumes on the encrypted StorageClass. Base stays
+# longhorn-retain so dev/staging are untouched (accepted-unencrypted, see
+# homelab docs/superpowers/specs/2026-07-13-encrypted-volume-migration-design.md).
+# storageClassName is immutable — landing this required deleting the prod
+# PVCs first (data was disposable); Argo recreated them empty on this SC.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kbk-player-pvc
+spec:
+  storageClassName: longhorn-encrypted
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kbk-sys-pvc
+spec:
+  storageClassName: longhorn-encrypted
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kbk-data-pvc
+spec:
+  storageClassName: longhorn-encrypted

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -13,4 +13,5 @@ commonLabels:
 
 patchesStrategicMerge:
   - kbk-configmap.yaml
+  - kbk-pvc-storage-patch.yaml
 


### PR DESCRIPTION
Flips the three kbk-prod PVCs to the cluster's encrypted storage class. Existing prod data is disposable (approved) — PVCs are recreated empty on the new class during a maintenance window. dev/staging untouched.