### PR TITLE
feat: HTTPRoute manifests for Gateway API dual-publish

### DIFF
--- a/k8s/overlays/dev/kbk-httproute.yaml
+++ b/k8s/overlays/dev/kbk-httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kbk
+spec:
+  hostnames:
+    - kbk-dev.bubtaylor.com
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: homelab-gateway
+      namespace: istio-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kbk-service
+          port: 80

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: kbk-dev
 
 resources:
   - namespace.yaml
+  - kbk-httproute.yaml
   - ../../base
 
 commonLabels:

--- a/k8s/overlays/kbk-staging/kbk-httproute.yaml
+++ b/k8s/overlays/kbk-staging/kbk-httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kbk
+spec:
+  hostnames:
+    - kbk-staging.bubtaylor.com
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: homelab-gateway
+      namespace: istio-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kbk-service
+          port: 80

--- a/k8s/overlays/kbk-staging/kustomization.yaml
+++ b/k8s/overlays/kbk-staging/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: kbk-staging
 
 resources:
   - namespace.yaml
+  - kbk-httproute.yaml
   - ../../base
 
 # Add namespace to all resources

--- a/k8s/overlays/prod/kbk-httproute.yaml
+++ b/k8s/overlays/prod/kbk-httproute.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kbk
+spec:
+  hostnames:
+    - kbk.bubtaylor.com
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: homelab-gateway
+      namespace: istio-ingress
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: kbk-service
+          port: 80

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -5,6 +5,7 @@ namespace: kbk-prod
 
 resources:
   - namespace.yaml
+  - kbk-httproute.yaml
   - ../../base
 
 # Add namespace to all resources


### PR DESCRIPTION
Phase 1 of the homelab gateway migration: adds Gateway API HTTPRoutes next to the existing Ingresses. Both serve the same hosts until Phase-3 retirement removes the Ingress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016vWxgJbueiDRUitmi2rnhw